### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/emreoztr/EZCache/security/code-scanning/1](https://github.com/emreoztr/EZCache/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, specifying the least privilege required. In this case, the workflow only needs to read the repository contents to check out the code, so the minimal permissions block should be `permissions: contents: read`. This block can be added at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. No additional imports or definitions are needed; simply add the block in the appropriate location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
