### PR TITLE
Refactor Thread Safety, Add new LRU algorithm and Change LRU Data Str…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,11 @@ add_library(EZCache::EZCache ALIAS EZCache)
 target_include_directories(EZCache INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_features(EZCache INTERFACE cxx_std_20)
 
-# (İsteğe bağlı ama IDE için faydalı) Header'ı hedefe iliştir
-# target_sources(EZCache INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/EZCache.hpp)
-
 ### BENCHMARK ###
 option(EZCACHE_BUILD_BENCHMARK "Build EZCache benchmark" OFF)
 if (EZCACHE_BUILD_BENCHMARK AND (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR))
     add_executable(benchmark benchmark/benchmark.cpp)
     target_link_libraries(benchmark PRIVATE EZCache)
-    # Release’ta optimize
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
         target_compile_options(benchmark PRIVATE $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native>)
         target_link_options(benchmark PRIVATE $<$<CONFIG:Release>:-flto>)

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -105,11 +105,10 @@ void benchmark_cold_loop(std::size_t N) {
     volatile int sink = 0;
 
     for (std::size_t i = 0; i < N; ++i) {
-        // her seferinde farklı key -> zorunlu miss
         int key = static_cast<int>(1000000 + i);
 
         auto t0 = clock::now();
-        int r = cache(common_lambda, key); // miss + insert (ve gerekirse eviction)
+        int r = cache(common_lambda, key); // miss + insert
         auto t1 = clock::now();
         sink ^= r;
 
@@ -124,8 +123,8 @@ void benchmark_cold_loop(std::size_t N) {
 }
 
 int main() {
-    benchmark_hot();
     benchmark_cold();
+    benchmark_hot();
     benchmark_expire();
     benchmark_lru();
     benchmark_type_mismatch();

--- a/tests/test_cache.cpp
+++ b/tests/test_cache.cpp
@@ -15,32 +15,73 @@ TEST(EZCache, HitMissCounters) {
 }
 
 TEST(EZCache, EvictionLRU) {
-    ezcache::EZCache<3, true> cache;
+    ezcache::EZCache<4, true> cache;
     auto f = [](int x){ return x * 2; };
 
     cache(f, 1); // miss
     cache(f, 2); // miss (cache: {2,1})
-    // LRU: [(f,2), (f,1)]
+    cache(f, 3); // miss
+    // LRU: [(f,3), (f,2), (f,1)]
 
-    EXPECT_EQ(cache.get_miss_count(), 2u);
+    EXPECT_EQ(cache.get_miss_count(), 3u);
     EXPECT_EQ(cache(f, 1), 2); // hit (LRU order update: {1,2})
-    // LRU: [(f,1), (f,2)]
+    // LRU: [(f,1), (f,3), (f,2)]
 
     EXPECT_EQ(cache.get_hit_count(), 1u);
-    cache(f, 3); // miss + evict 2 (cache: {3,1})
-    // LRU: [(f,3), (f,1)]
-    EXPECT_EQ(cache.get_miss_count(), 3u);
-
-    EXPECT_EQ(cache(f, 2), 4); // miss again, 2 evicted
-    // LRU: [(f,2), (f,3)]
+    cache(f, 4); // miss
+    // LRU: [(f,4), (f,1), (f,3)]
     EXPECT_EQ(cache.get_miss_count(), 4u);
 
-    EXPECT_EQ(cache(f, 1), 2); // miss again, 1 evicted
-    // LRU: [(f,1), (f,2)]
+    EXPECT_EQ(cache(f, 2), 4); // miss again, 2 evicted
+    // LRU: [(f,2), (f,4), (f,1)]
     EXPECT_EQ(cache.get_miss_count(), 5u);
-    EXPECT_EQ(cache.get_hit_count(), 1u);
+
+    EXPECT_EQ(cache(f, 1), 2); // hit
+    // LRU: [(f,1), (f,2), (f,4)]
+    cache(f, 3); // miss
+    EXPECT_EQ(cache.get_miss_count(), 6u);
+    EXPECT_EQ(cache.get_hit_count(), 2u);
 }
 
+TEST(EZCache, EvictionLRUInLoop) {
+    ezcache::EZCache<101, true> cache;
+    auto f = [](int x){ return x * 2; };
+    for (auto i = 0; i < 100; i++) {
+        cache(f, i);
+    }
+    EXPECT_EQ(cache.get_miss_count(), 100u);
+
+    for (auto i = 0; i < 40; i++) {
+        cache(f, i);
+    }
+    EXPECT_EQ(cache.get_miss_count(), 100u);
+    EXPECT_EQ(cache.get_hit_count(), 40u);
+
+    for (auto i = 100; i < 120; i++) { //evicts 30 entry [40,70)
+        cache(f, i);
+    }
+    EXPECT_EQ(cache.get_miss_count(), 120u);
+    EXPECT_EQ(cache.get_hit_count(), 40u);
+    // (120, 100] + (40, 0] + [100, 70)
+
+    for (auto i = 0; i < 40; i++) {
+        cache(f, i);
+    }
+    EXPECT_EQ(cache.get_miss_count(), 120u);
+    EXPECT_EQ(cache.get_hit_count(), 80u);
+
+    for (auto i = 70; i < 120; i++) {
+        cache(f, i);
+    }
+    EXPECT_EQ(cache.get_miss_count(), 120u);
+    EXPECT_EQ(cache.get_hit_count(), 130u);
+
+    for (auto i = 40; i < 70; i++) {
+        cache(f, i);
+    }
+    EXPECT_EQ(cache.get_miss_count(), 150u);
+    EXPECT_EQ(cache.get_hit_count(), 130u);
+}
 
 TEST(EZCache, Expiration) {
     using namespace std;


### PR DESCRIPTION
…ucture

Changed from classic mutex to shared mutex, to be able to use shared lock for get operations in favor of performance.

Changed LRU from linked list to vector and, LRU clear algorithm to make it compatible with shared lock mechanism and address data-race issues. Added new and detailed unit test about this change.